### PR TITLE
Use the value from the branch parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,7 @@ runs:
         INPUT_COAUTHOR_EMAIL: ${{ inputs.coauthor_email }}
         INPUT_COAUTHOR_NAME: ${{ inputs.coauthor_name }}
         INPUT_MESSAGE: ${{ inputs.message }}
+        INPUT_BRANCH: ${{ inputs.branch }}
         INPUT_EMPTY: ${{ inputs.empty }}
         INPUT_FORCE: ${{ inputs.force }}
         INPUT_REBASE: ${{ inputs.rebase }}

--- a/start.sh
+++ b/start.sh
@@ -50,7 +50,7 @@ if [ -n "${INPUT_COAUTHOR_EMAIL}" ] && [ -n "${INPUT_COAUTHOR_NAME}" ]; then
 
 Co-authored-by: ${INPUT_COAUTHOR_NAME} <${INPUT_COAUTHOR_EMAIL}>" $_EMPTY || true
 else
-    git commit -m "{$INPUT_MESSAGE}" $_EMPTY || true
+    git commit -m "${INPUT_MESSAGE}" $_EMPTY || true
 fi
 echo 'Comitted'
 


### PR DESCRIPTION
The `branch` parameter of this Github Action was not actually being used because the environment variable was not being set. This fixes that problem and makes the Action actually work on any other branch besides `master` (e.g. `main`).